### PR TITLE
feat(): readyNotice as function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,8 +153,9 @@ function initCtx(options) {
        || !isFileFound(targetSvc)                 && options.svc + ' is not found on disk'
        || !options.logPath                        && 'options.logPath is expected to be a path'
        || 'string' != typeof options.logPath      && 'options.logPath is expected to be a path'
-       || !options.readyNotice                    && 'options.readyNotice must be a string'
-       || 'string' != typeof options.readyNotice  && 'options.readyNotice must be a string'
+       || !options.readyNotice                    && 'options.readyNotice must be either a string or a function'
+       || ['string', 'function']
+            .indexOf(typeof options.readyNotice)  && 'options.readyNotice must be either a string or a function'
        || !Array.isArray(options.args)            && 'options.args must be an array'
        || 'number' != typeof options.timeout      && 'options.timeout must be a number'
        || 'number' != typeof options.slow         && 'options.slow must be a number'
@@ -235,10 +236,11 @@ function initCtx(options) {
   @param {string} ctx.sut - system under test - path to the script that
      runs the target server
   @param {string} ctx.logPath - path to log file
-  @param {string} ctx.readyNotice - output line expected on stdout of
-     the started target service that indicates that the service is running
+  @param {string|function} ctx.readyNotice - either output line expected on stdout of
+     the started target service that indicates that the service is running or a function that will
+     check that the service is up
   @param {mocha.Test} test - the test context that implements .timetout(n), .slow(n) ....
-  @param {callback} done - callback
+  @param {function} done - callback
   @returns {undefined}
  */
 function setup(ctx, test, done) {
@@ -284,13 +286,20 @@ function setup(ctx, test, done) {
     child.stdout.on('data', (data) => {
         data = data.toString()
         writeLog(data)
-
-        if (~data.indexOf(ctx.readyNotice)) {
-            ctx.console.log('service started: %s', ctx.args.join(' '))
-            done()
-            done = null
-        }
     })
+
+    if ('function' == typeof ctx.readyNotice) {
+        ctx.readyNotice(done)
+        done = null
+    } else {
+        child.stdout.on('data', (data) => {
+            if (done && ~data.indexOf(ctx.readyNotice)) {
+                ctx.console.log('service started: %s', ctx.args.join(' '))
+                done()
+                done = null
+            }
+        })
+    }
 
     child.on('exit', (e) => {
         child.exitted = true

--- a/lib/index.js
+++ b/lib/index.js
@@ -184,7 +184,7 @@ function initCtx(options) {
         , " - logPath - string, optional - path to logfile. default: './e2e.log'"
         , " - timeout - integer, optional - timeout for server setup, default: " + defaults.timeout
         , " - slow - integer, optional - slow bar indicator for server setup, default: " + defaults.timeout
-        , " - readyNotice - string, optional - message to expect on service output that"
+        , " - readyNotice - string or function, optional - message to expect on service output that"
         , "   indicates the service is ready. default: " + defaults.readyNotice
         , " - args - array, optional, argumnets to be concatenated to the running command"
         , " - term_code - string, optional, the termination message to send to the child, default: " + defaults.term_code

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-helper",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "end-to-end test helper, with facilitators for mocha",
   "main": "lib",
   "repository": {

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -56,14 +56,14 @@ module.exports =
                 { svc: 'test/fixture/svc'
                 , readyNotice: null
                 }
-              , m: 'options.readyNotice must be a string'
+              , m: 'options.readyNotice must be either a string or a function'
               }
             , 'options.readyNotice not a string':
               { o:
                 { svc: 'test/fixture/svc'
                 , readyNotice: -0.431
                 }
-              , m: 'options.readyNotice must be a string'
+              , m: 'options.readyNotice must be either a string or a function'
               }
             , 'options.args not an array':
               { o:


### PR DESCRIPTION
Support passing a method as a readyNotice that will be called instead of listening to text message